### PR TITLE
Update data refresh workflow to stage hitter and pitcher CSVs

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add full_stats.csv player_names.csv
+          git add full_stats_hitters.csv player_names_hitters.csv full_stats_pitchers.csv player_names_pitchers.csv
           git diff --staged --quiet || git commit -m "Daily data refresh $(date)"
           git push


### PR DESCRIPTION
## Summary
- Update refresh-data workflow to add hitter and pitcher CSVs when committing data updates

## Testing
- `pytest >/tmp/pytest.log || echo 'pytest command failed'; tail -n 20 /tmp/pytest.log`
- `npm test >/tmp/npm.log || echo 'npm test failed'; tail -n 20 /tmp/npm.log`


------
https://chatgpt.com/codex/tasks/task_e_689258277c74832bbab0dd705528bfc6