### PR TITLE
Revert pitcher additions

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add full_stats_hitters.csv player_names_hitters.csv full_stats_pitchers.csv player_names_pitchers.csv
+          git add full_stats.csv player_names.csv
           git diff --staged --quiet || git commit -m "Daily data refresh $(date)"
           git push

--- a/app/app.R
+++ b/app/app.R
@@ -23,31 +23,23 @@ load_baseball_data <- function() {
 
       cat("Attempting to load data from:", base_url, "\n")
 
-      full_stats_hitters <- read_csv(paste0(base_url, "full_stats_hitters.csv"), show_col_types = FALSE)
-      full_stats_pitchers <- read_csv(paste0(base_url, "full_stats_pitchers.csv"), show_col_types = FALSE)
-      cat("Loaded hitter stats with", nrow(full_stats_hitters), "rows\n")
-      cat("Loaded pitcher stats with", nrow(full_stats_pitchers), "rows\n")
+      full_stats <- read_csv(paste0(base_url, "full_stats_hitters.csv"), show_col_types = FALSE)
+      cat("Loaded full_stats with", nrow(full_stats), "rows\n")
 
-      player_names_hitters <- read_csv(paste0(base_url, "player_names_hitters.csv"), show_col_types = FALSE)
-      player_names_pitchers <- read_csv(paste0(base_url, "player_names_pitchers.csv"), show_col_types = FALSE)
-      cat("Loaded hitter names with", nrow(player_names_hitters), "rows\n")
-      cat("Loaded pitcher names with", nrow(player_names_pitchers), "rows\n")
+      player_names <- read_csv(paste0(base_url, "player_names_hitters.csv"), show_col_types = FALSE)
+      cat("Loaded player_names with", nrow(player_names), "rows\n")
 
       list(
-        full_stats_hitters = full_stats_hitters,
-        full_stats_pitchers = full_stats_pitchers,
-        player_names_hitters = player_names_hitters,
-        player_names_pitchers = player_names_pitchers
+        full_stats = full_stats,
+        player_names = player_names
       )
     },
     error = function(e) {
       cat("Error loading data:", e$message, "\n")
       # Return empty data instead of NULL
       list(
-        full_stats_hitters = data.frame(),
-        full_stats_pitchers = data.frame(),
-        player_names_hitters = data.frame(Name = character(0)),
-        player_names_pitchers = data.frame(Name = character(0))
+        full_stats = data.frame(),
+        player_names = data.frame(Name = character(0))
       )
     }
   )
@@ -55,9 +47,8 @@ load_baseball_data <- function() {
 
 # ChatGPT integration
 generate_gpt_analysis <- function(player_name, prompt_text, analysis_mode = "default") {
-  prompt_modifier <- switch(
-    analysis_mode,
-    "analytics_dork" = "You are a front office nerd, raised on moneyball and new school stats, always at the cutting edge. You favor new school stats, talk in probabilities, and are very dismissive of people who don't believe you. You might be the smartest person in the room, but people would describe you as a real tool. Be ruthless and dismissive!",
+  prompt_modifier <- switch(analysis_mode,
+    "analytics_dork" = "You are a front office nerd, raised on moneyball and new school stats, always at the cutting edge. You favor new school stats, talk in probabilities, and are very dismissive of people who don't believe you. You might be the smartet person in the room, but people would describe you as a real tool. Be ruthless and dismissive!",
     "old_coot" = "You are a deranged old coot, ranting and raving about everything. Yell a lot. People would describe you as 'off your meds'. Throw in references to people spying on you. Appear confused at times. Get stats wrong occasionally. You know, just -- be insane.",
     "gen_z" = "You're an over the top Gen Z'er, using lots of slang, referencing hyper modern trends, apps, emojis, and such. But really lay it on thick, in a humorously over-the-top kind of way.",
     "seventies" = "You prefer 1970s style of baseball, when men were men, stolen bases were high, starting pitchers completed every game, and guys had bushy mustaches and chewed tobacco all game. You strongly prefer old school stats to new school ones. Use lots of comparisons to famous 1970s baseball players: Pete Rose, Johnny Bench, Mike Schmidt, Willie Stargell, Rod Carew, Bobby Grich, Thurman Munson, etc -- but don't limit your comparisons to just these guys.",
@@ -113,69 +104,61 @@ Here is your persona that should inform your writing style and response, even if
 }
 
 # function to analyze a given player
-analyze_player <- function(player_name, analysis_mode = "default", full_stats, current_year, player_type = "hitter") {
+analyze_player <- function(player_name, analysis_mode = "default", full_stats, current_year) {
   data <- full_stats |> filter(trimws(tolower(Name)) == trimws(tolower(player_name)))
-  if (player_type == "hitter") {
-    prompt <- glue(
-      "Player: {player_name}
+  prompt <- glue(
+    "Player: {player_name}
 
---- Key metrics to analyze---",
-      "Age: {data$Age}",
-      "Year: {current_year}",
-      "Plate Appearances (PA): {data$PA_cur}",
-      "AVG: {data$AVG_cur}  Last 3 Years: {data$AVG_l3}  Diff: {data$AVG_diff}",
-      "OBP: {data$OBP_cur}  Last 3 Years: {data$OBP_l3}  Diff: {data$OBP_diff}",
-      "SLG: {data$SLG_cur}  Last 3 Years: {data$SLG_l3}  Diff: {data$SLG_diff}",
-      "K%: {data$K_pct_cur}  Last 3 Years: {data$K_pct_l3}  Diff: {data$K_pct_diff}",
-      "BB%: {data$BB_pct_cur}  Last 3 Years: {data$BB_pct_l3}  Diff: {data$BB_pct_diff}",
-      "Barrel%: {data$Barrel_pct_cur} Last 3 years: {data$Barrel_pct_l3} Diff: {data$Barrel_pct_diff}",
-      "BABIP: {data$BABIP_cur}  Last 3 Years: {data$BABIP_l3}  Diff: {data$BABIP_diff}",
-      "wOBA: {data$wOBA_cur}  Last 3 Years: {data$wOBA_l3}  Diff: {data$wOBA_diff}",
-      "xwOBA: {data$xwOBA_cur}  Last 3 Years: {data$xwOBA_l3}  Diff: {data$xwOBA_diff}",
-      "xwOBA wOBA gap: {data$xwOBA_wOBA_gap_cur} Last 3 Years: {data$xwOBA_wOBA_gap_l3}  Diff: {data$xwOBA_wOBA_gap_diff}",
-      "--- Notes for analysis ---",
-      "- Focus on current-year performance compared to the last three years explanations.",
-      "- BABIP above/below norms indicates luck.",
-      "- Gaps between wOBA and xwOBA signal luck vs skill, unless that gap is close to what it has been historically.",
-      "- Remember that xwOBA includes contact quality and plate discipline.",
-      "- BB%/K% changes reflect plate discpline skills, which are more sustainable than batted-ball performance generally.",
-      "- Take age into account. Older players less likely to improve; younger trend upward. Players generally peak in their early to mid 20's now.",
-      "- High Barrel% indiciates the player is hitting the ball hard at ideal launch angles. Changes are indicate legitimate improvements or declines. Higher Barrel% should mean higher BABIP, higher wOBA, and higher xWOBA -- unless bad luck is a significant factor.",
-      "- Incorporate injuries or known context.",
-      "- For small samples, be cautious with conclusions. For context, larger samples trend towards hundreds of PA. A full season is ~600 PA."
-    )
-  } else {
-    prompt <- glue(
-      "Player: {player_name}
+--- Key metrics to analyze---
+",
+    "Age: {data$Age}
+",
+    "Year: {current_year}
+",
+    "Plate Appearances (PA): {data$PA_cur}
+",
+    "AVG: {data$AVG_cur}  Last 3 Years: {data$AVG_l3}  Diff: {data$AVG_diff}
+",
+    "OBP: {data$OBP_cur}  Last 3 Years: {data$OBP_l3}  Diff: {data$OBP_diff}
+",
+    "SLG: {data$SLG_cur}  Last 3 Years: {data$SLG_l3}  Diff: {data$SLG_diff}
+",
+    "K%: {data$K_pct_cur}  Last 3 Years: {data$K_pct_l3}  Diff: {data$K_pct_diff}
+",
+    "BB%: {data$BB_pct_cur}  Last 3 Years: {data$BB_pct_l3}  Diff: {data$BB_pct_diff}
+",
+    "Barrel% {data$Barrel_pct_cur} Last 3 years: {data$Barrel_pct_l3} Diff: {data$Barrel_pct_diff}",
+    "BABIP: {data$BABIP_cur}  Last 3 Years: {data$BABIP_l3}  Diff: {data$BABIP_diff}
+",
+    "wOBA: {data$wOBA_cur}  Last 3 Years: {data$wOBA_l3}  Diff: {data$wOBA_diff}
+",
+    "xwOBA: {data$xwOBA_cur}  Last 3 Years: {data$xwOBA_l3}  Diff: {data$xwOBA_diff}
 
---- Key metrics to analyze---",
-      "Age: {data$Age}",
-      "Year: {current_year}",
-      "Innings Pitched (IP): {data$IP_cur}",
-      "ERA: {data$ERA_cur}  Last 3 Years: {data$ERA_l3}  Diff: {data$ERA_diff}",
-      "xERA: {data$xERA_cur}  Last 3 Years: {data$xERA_l3}  Diff: {data$xERA_diff}",
-      "FIP: {data$FIP_cur}  Last 3 Years: {data$FIP_l3}  Diff: {data$FIP_diff}",
-      "xFIP: {data$xFIP_cur}  Last 3 Years: {data$xFIP_l3}  Diff: {data$xFIP_diff}",
-      "K%: {data$K_pct_cur}  Last 3 Years: {data$K_pct_l3}  Diff: {data$K_pct_diff}",
-      "BB%: {data$BB_pct_cur}  Last 3 Years: {data$BB_pct_l3}  Diff: {data$BB_pct_diff}",
-      "K-BB%: {data$K_BB_pct_cur}  Last 3 Years: {data$K_BB_pct_l3}  Diff: {data$K_BB_pct_diff}",
-      "Barrel%: {data$Barrel_pct_cur} Last 3 years: {data$Barrel_pct_l3} Diff: {data$Barrel_pct_diff}",
-      "BABIP: {data$BABIP_cur}  Last 3 Years: {data$BABIP_l3}  Diff: {data$BABIP_diff}",
-      "LOB%: {data$LOB_pct_cur}  Last 3 Years: {data$LOB_pct_l3}  Diff: {data$LOB_pct_diff}",
-      "--- Notes for analysis ---",
-      "- Focus on current-year performance compared to the last three years explanations.",
-      "- BABIP above/below norms indicates luck.",
-      "- Differences between ERA and xERA or FIP may point to luck or defense.",
-      "- K%/BB% changes reflect command and stuff.",
-      "- Take age into account and consider workload.",
-      "- Incorporate injuries or known context.",
-      "- For small samples, be cautious with conclusions. Pitchers can be volatile in small IP samples."
-    )
-  }
+",
+    "xwOBA wOBA gap: {data$xwOBA_wOBA_gap_cur} Last 3 Years: {data$xwOBA_wOBA_gap_l3}  Diff: {data$xwOBA_wOBA_gap_diff}",
+    "--- Notes for analysis ---
+",
+    "- Focus on current-year performance compared to the last three years explanations.
+",
+    "- BABIP above/below norms indicates luck.
+",
+    "- Gaps between wOBA and xwOBA signal luck vs skill, unless that gap is close to what it has been historically.
+",
+    "- Remember that xwOBA includes contact quality and plate discipline.
+",
+    "- BB%/K% changes reflect plate discpline skills, which are more sustainable than batted-ball performance generally.
+",
+    "- Take age into account. Older players less likely to improve; younger trend upward. Players generally peak in their early to mid 20's now.
+",
+    "- High Barrel% indiciates the player is hitting the ball hard at ideal launch angles. Changes are indicate legitimate improvements or declines. Higher Barrel% should mean higher BABIP, higher wOBA, and higher xWOBA -- unless bad luck is a significant factor.",
+    "- Incorporate injuries or known context.
+",
+    "- For small samples, be cautious with conclusions. For context, larger samples trend towards hundreds of PA. A full season is ~600 PA."
+  )
   generate_gpt_analysis(player_name, prompt, analysis_mode)
 }
 
-prepare_player_comparison <- function(player_name, full_stats_data, player_type = "hitter") {
+prepare_player_comparison <- function(player_name, full_stats_data) {
   library(tidyr)
   library(dplyr)
 
@@ -184,11 +167,7 @@ prepare_player_comparison <- function(player_name, full_stats_data, player_type 
     filter(Name == player_name)
 
   # Define the metrics we want to compare (without suffixes)
-  base_metrics <- if (player_type == "hitter") {
-    c("AVG", "OBP", "SLG", "K_pct", "BB_pct", "Barrel_pct", "BABIP", "wOBA", "xwOBA", "xWOBA_wOBA_gap")
-  } else {
-    c("ERA", "xERA", "FIP", "xFIP", "K_pct", "BB_pct", "K_BB_pct", "Barrel_pct", "BABIP", "LOB_pct")
-  }
+  base_metrics <- c("AVG", "OBP", "SLG", "K_pct", "BB_pct", "Barrel_pct", "BABIP", "wOBA", "xwOBA", "xWOBA_wOBA_gap")
 
   # Create comparison data
   comparison_data <- tibble()
@@ -228,18 +207,16 @@ create_comparison_plot <- function(comparison_data, selected_metrics = NULL) {
   }
 
   # Clean up metric names for display
-    comparison_data <- comparison_data |>
-      mutate(
-        metric_display = case_when(
-          metric == "K_pct" ~ "K%",
-          metric == "BB_pct" ~ "BB%",
-          metric == "K_BB_pct" ~ "K-BB%",
-          metric == "Barrel_pct" ~ "Barrel%",
-          metric == "xWOBA_wOBA_gap" ~ "xwOBA - wOBA",
-          metric == "LOB_pct" ~ "LOB%",
-          TRUE ~ metric
-        )
+  comparison_data <- comparison_data |>
+    mutate(
+      metric_display = case_when(
+        metric == "K_pct" ~ "K%",
+        metric == "BB_pct" ~ "BB%",
+        metric == "Barrel_pct" ~ "Barrels/PA",
+        metric == "data$xWOBA_wOBA_gap_" ~ "xwOBA - wOBA",
+        TRUE ~ metric
       )
+    )
 
   # Create the plot
   ggplot(comparison_data, aes(
@@ -335,33 +312,21 @@ ui <- page_navbar(
       # Column 1: “picker” card
       card(
         #   card_header("McFARLAND"),
-          card_body(
-            pickerInput(
-              inputId = "player_type",
-              label = "Player type:",
-              choices = c("Hitter" = "hitter", "Pitcher" = "pitcher"),
-              selected = "hitter",
-              multiple = FALSE,
-              width = "100%",
-              options = pickerOptions(
-                container = "body",
-                dropupAuto = FALSE
-              )
-            ),
-            pickerInput(
-              inputId = "player_name",
-              label = "Player:",
-              choices = NULL,
-              multiple = FALSE,
-              width = "100%",
-              options = pickerOptions(
-                container = "body",
-                dropupAuto = FALSE,
-                liveSearch = TRUE,
-                liveSearchStyle = "contains",
-                liveSearchPlaceholder = "Search for a player..."
-              )
-            ),
+        card_body(
+          pickerInput(
+            inputId = "player_name",
+            label = "Player:",
+            choices = NULL,
+            multiple = FALSE,
+            width = "100%",
+            options = pickerOptions(
+              container = "body",
+              dropupAuto = FALSE,
+              liveSearch = TRUE,
+              liveSearchStyle = "contains",
+              liveSearchPlaceholder = "Search for a player..."
+            )
+          ),
           pickerInput(
             inputId = "analysis_mode",
             label = "Vibe:",
@@ -416,7 +381,7 @@ ui <- page_navbar(
           src = "tjmcfarland.png",
           style = "width: 100%; max-width: 400px; height: auto;"
         ),
-        p("Includes hitters and pitchers."),
+        p("Hitters only (for now)."),
         p("Data from FanGraphs. Comparing 2025 stats (refreshed daily) to 2022-2024 averages."),
         p("Built with R, shiny, tidyverse, baseballr, bslib, shinyWidgets, and shinybusy."),
         p("Powered by gpt-4.1."),
@@ -439,14 +404,13 @@ ui <- page_navbar(
         ),
         
         h4("Version History"),
-          tags$ul(
-            tags$li("0.6 - Added pitcher support."),
-            tags$li("0.5 - Added ability to sign up for notifications."),
-            tags$li("0.4 - Added Barrels/PA and historical xwOBA/wOBA gap to stats that are analyzed"),
-            tags$li("0.3 - Added player stat graphs below analysis."),
-            tags$li("0.2 - Added Shakespeare vibe."),
-            tags$li("0.1 - First version I wasn't horrendously ashamed of.")
-          )
+        tags$ul(
+          tags$li("0.5 - Added ability to sign up for notifications."),
+          tags$li("0.4 - Added Barrels/PA and historical xwOBA/wOBA gap to stats that are analyzed"),
+          tags$li("0.3 - Added player stat graphs below analysis."),
+          tags$li("0.2 - Added Shakespeare vibe."),
+          tags$li("0.1 - First version I wasn't horrendously ashamed of.")
+        )
       )
     )
   )
@@ -460,39 +424,30 @@ server <- function(input, output, session) {
 
   # Load data once when app starts
   baseball_data <- load_baseball_data()
-  full_stats_hitters <- baseball_data$full_stats_hitters
-  full_stats_pitchers <- baseball_data$full_stats_pitchers
-  player_names_hitters <- baseball_data$player_names_hitters
-  player_names_pitchers <- baseball_data$player_names_pitchers
+  full_stats <- baseball_data$full_stats
+  player_names <- baseball_data$player_names
 
-  observe({
-    if (input$player_type == "hitter") {
-      updatePickerInput(session, "player_name", choices = c("", player_names_hitters$Name))
-    } else {
-      updatePickerInput(session, "player_name", choices = c("", player_names_pitchers$Name))
-    }
-  })
+
+  if (!is.null(baseball_data) && nrow(baseball_data$player_names) > 0) {
+    # Update the picker with actual player names
+    updatePickerInput(
+      session = session,
+      inputId = "player_name",
+      choices = c("", baseball_data$player_names$Name)
+    )
+  }
 
   output$result_wrapper <- renderUI({
-    full_stats <- if (input$player_type == "hitter") full_stats_hitters else full_stats_pitchers
-    player_names <- if (input$player_type == "hitter") player_names_hitters else player_names_pitchers
-
     # ensure we're about to analyze a valid player name.
     shiny::validate(
       need(input$player_name %in% player_names$Name, "Enter a valid player name.")
     )
 
     # Get the main analysis
-    main_analysis <- analyze_player(
-      player_name   = input$player_name,
-      analysis_mode = input$analysis_mode,
-      full_stats    = full_stats,
-      current_year  = current_year,
-      player_type   = input$player_type
-    )
+    main_analysis <- analyze_player(input$player_name, input$analysis_mode, full_stats, current_year)
 
     # Prepare comparison data
-    player_comparison <- prepare_player_comparison(input$player_name, full_stats, input$player_type)
+    player_comparison <- prepare_player_comparison(input$player_name, full_stats)
 
     # Combine everything
     tagList(

--- a/refresh_data.R
+++ b/refresh_data.R
@@ -5,12 +5,13 @@ library(stringi)
 
 current_year <- 2025
 
-# ------------------- Hitters -------------------
-batter_stats <-
+# Load static data 
+stats <-
   bind_rows(
     read_csv("fangraphs-leaderboards-2022.csv", show_col_types = FALSE) |> mutate(year = 2022),
     read_csv("fangraphs-leaderboards-2023.csv", show_col_types = FALSE) |> mutate(year = 2023),
     read_csv("fangraphs-leaderboards-2024.csv", show_col_types = FALSE) |> mutate(year = 2024),
+    # This is the part that changes daily
     fg_batter_leaders(pos = "np", startseason = current_year, endseason = current_year) |>
       select(Name = PlayerName, Age, PlayerId = playerid, AB, PA, `1B`, `2B`, `3B`, HR, H, HBP, SF, wOBA, xwOBA, SO, BB, Barrels) |>
       mutate(year = current_year)
@@ -20,8 +21,9 @@ batter_stats <-
     Name = stri_trans_general(Name, id = "Latin-ASCII")
   )
 
-last_3_hitters <-
-  batter_stats |>
+# Compute stats for the past 3 years
+last_3 <-
+  stats |>
   filter(year != current_year) |>
   group_by(Name, PlayerId) |>
   summarize(
@@ -39,8 +41,9 @@ last_3_hitters <-
     .groups = "drop"
   )
 
-this_year_hitters <-
-  batter_stats |>
+# Compute stats for current year
+this_year <-
+  stats |>
   filter(year == current_year) |>
   group_by(Name, PlayerId) |>
   summarize(
@@ -59,9 +62,10 @@ this_year_hitters <-
     .groups = "drop"
   )
 
-full_stats_hitters <-
-  this_year_hitters |>
-  left_join(last_3_hitters, by = c("Name", "PlayerId"), suffix = c("_cur", "_l3")) |>
+# Combine and compute differences
+full_stats <-
+  this_year |>
+  left_join(last_3, by = c("Name", "PlayerId"), suffix = c("_cur", "_l3")) |>
   mutate(
     AVG_diff = AVG_cur - AVG_l3,
     OBP_diff = OBP_cur - OBP_l3,
@@ -76,90 +80,13 @@ full_stats_hitters <-
   ) |>
   mutate(across(where(is.numeric), ~ round(.x, 3)))
 
-player_names_hitters <-
-  this_year_hitters |>
+player_names <-
+  this_year |>
   select(Name) |>
   distinct()
 
-# ------------------- Pitchers -------------------
-pitcher_stats <-
-  bind_rows(
-    read_csv("pitcher-stats-2022.csv", show_col_types = FALSE) |> mutate(year = 2022),
-    read_csv("pitcher-stats-2023.csv", show_col_types = FALSE) |> mutate(year = 2023),
-    read_csv("pitcher-stats-2024.csv", show_col_types = FALSE) |> mutate(year = 2024),
-    fg_pitcher_leaders(startseason = current_year, endseason = current_year) |>
-      select(playerid, name, age, ip, tbf, h, er, hr, so, bb, babip, lob_percent, fip, x_fip, x_era, barrels, barrel_percent, k_percent, bb_percent, k_minus_bb_percent, era) |>
-      rename(PlayerId = playerid, Name = name, Age = age) |>
-      mutate(year = current_year)
-  ) |>
-  mutate(Name = stri_trans_general(Name, id = "Latin-ASCII"))
-
-last_3_pitchers <-
-  pitcher_stats |>
-  filter(year != current_year) |>
-  group_by(Name, PlayerId) |>
-  summarize(
-    ERA = weighted.mean(era, w = ip, na.rm = TRUE),
-    xERA = weighted.mean(x_era, w = ip, na.rm = TRUE),
-    FIP = weighted.mean(fip, w = ip, na.rm = TRUE),
-    xFIP = weighted.mean(x_fip, w = ip, na.rm = TRUE),
-    K_pct = 100 * sum(so) / sum(tbf),
-    BB_pct = 100 * sum(bb) / sum(tbf),
-    K_BB_pct = K_pct - BB_pct,
-    Barrel_pct = 100 * sum(barrels) / sum(tbf),
-    BABIP = weighted.mean(babip, w = ip, na.rm = TRUE),
-    LOB_pct = weighted.mean(lob_percent, w = ip, na.rm = TRUE),
-    IP = sum(ip),
-    .groups = "drop"
-  )
-
-this_year_pitchers <-
-  pitcher_stats |>
-  filter(year == current_year) |>
-  group_by(Name, PlayerId) |>
-  summarize(
-    ERA = weighted.mean(era, w = ip, na.rm = TRUE),
-    xERA = weighted.mean(x_era, w = ip, na.rm = TRUE),
-    FIP = weighted.mean(fip, w = ip, na.rm = TRUE),
-    xFIP = weighted.mean(x_fip, w = ip, na.rm = TRUE),
-    K_pct = 100 * sum(so) / sum(tbf),
-    BB_pct = 100 * sum(bb) / sum(tbf),
-    K_BB_pct = K_pct - BB_pct,
-    Barrel_pct = 100 * sum(barrels) / sum(tbf),
-    BABIP = weighted.mean(babip, w = ip, na.rm = TRUE),
-    LOB_pct = weighted.mean(lob_percent, w = ip, na.rm = TRUE),
-    IP = sum(ip),
-    Age = first(Age),
-    .groups = "drop"
-  )
-
-full_stats_pitchers <-
-  this_year_pitchers |>
-  left_join(last_3_pitchers, by = c("Name", "PlayerId"), suffix = c("_cur", "_l3")) |>
-  mutate(
-    ERA_diff = ERA_cur - ERA_l3,
-    xERA_diff = xERA_cur - xERA_l3,
-    FIP_diff = FIP_cur - FIP_l3,
-    xFIP_diff = xFIP_cur - xFIP_l3,
-    K_pct_diff = K_pct_cur - K_pct_l3,
-    BB_pct_diff = BB_pct_cur - BB_pct_l3,
-    K_BB_pct_diff = K_BB_pct_cur - K_BB_pct_l3,
-    Barrel_pct_diff = Barrel_pct_cur - Barrel_pct_l3,
-    BABIP_diff = BABIP_cur - BABIP_l3,
-    LOB_pct_diff = LOB_pct_cur - LOB_pct_l3
-  ) |>
-  mutate(across(where(is.numeric), ~ round(.x, 3)))
-
-player_names_pitchers <-
-  this_year_pitchers |>
-  select(Name) |>
-  distinct()
-
-# ------------------- Save -------------------
-write_csv(full_stats_hitters, "full_stats_hitters.csv")
-write_csv(player_names_hitters, "player_names_hitters.csv")
-write_csv(full_stats_pitchers, "full_stats_pitchers.csv")
-write_csv(player_names_pitchers, "player_names_pitchers.csv")
+# Save the processed data
+write_csv(full_stats, "full_stats.csv")
+write_csv(player_names, "player_names.csv")
 
 cat("Data refreshed at:", as.character(Sys.time()), "\n")
-


### PR DESCRIPTION
## Summary
- Revert app to load and return only hitter stats and names.
- Simplify data refresh script to output unified hitter CSVs.
- Update workflow to commit full_stats.csv and player_names.csv only.

## Testing
- `R -q -e 'lintr::lint("app/app.R")'` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*
- `python3 -m pip install --user yamllint` *(fails: tunnel connection 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f9e73b96c832ba8f55c6eafae17a7